### PR TITLE
MAV-549 fix

### DIFF
--- a/allauth/socialaccount/providers/klaviyo_oauth2/provider.py
+++ b/allauth/socialaccount/providers/klaviyo_oauth2/provider.py
@@ -15,7 +15,10 @@ class KlaviyoProvider(OAuth2Provider):
     oauth2_adapter_class = KlaviyoOAuth2Adapter
 
     def extract_uid(self, data):
-        return data.get("data", [{}])[0].get("id")
+        data = data.get("data", [{}])
+        if data:
+            return data[0].get("id")
+        return None
 
     def get_default_scope(self):
         return ["accounts:read"]

--- a/allauth/socialaccount/providers/klaviyo_oauth2/provider.py
+++ b/allauth/socialaccount/providers/klaviyo_oauth2/provider.py
@@ -15,9 +15,9 @@ class KlaviyoProvider(OAuth2Provider):
     oauth2_adapter_class = KlaviyoOAuth2Adapter
 
     def extract_uid(self, data):
-        data = data.get("data", [{}])
-        if data:
-            return data[0].get("id")
+        result = data.get("data", [{}])
+        if result:
+            return result[0].get("id")
         return None
 
     def get_default_scope(self):

--- a/allauth/socialaccount/providers/klaviyo_oauth2/provider.py
+++ b/allauth/socialaccount/providers/klaviyo_oauth2/provider.py
@@ -15,7 +15,7 @@ class KlaviyoProvider(OAuth2Provider):
     oauth2_adapter_class = KlaviyoOAuth2Adapter
 
     def extract_uid(self, data):
-        return data.get("data", {})[0].get("id")
+        return data.get("data", [{}])[0].get("id")
 
     def get_default_scope(self):
         return ["accounts:read"]


### PR DESCRIPTION
``` Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/allauth/socialaccount/providers/oauth2/views.py", line 103, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/allauth/socialaccount/providers/oauth2/views.py", line 147, in dispatch
    login = self.adapter.complete_login(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/allauth/socialaccount/providers/klaviyo_oauth2/views.py", line 37, in complete_login
    return self.get_provider().sociallogin_from_response(request, extra_data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/allauth/socialaccount/providers/base/provider.py", line 105, in sociallogin_from_response
    uid = self.extract_uid(response)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/allauth/socialaccount/providers/klaviyo_oauth2/provider.py", line 18, in extract_uid
    return data.get("data", {})[0].get("id")
           ~~~~~~~~~~~~~~~~~~~~^^^
KeyError: 0
